### PR TITLE
install.sh: remove gratuitous resolution of a static string

### DIFF
--- a/files/installer/install.sh
+++ b/files/installer/install.sh
@@ -113,7 +113,7 @@ get_factory_eeprom() {
 
   [ -d "$FACTORY_TMP" ] || mkdir -p "$FACTORY_TMP"
 
-  ebs="$(cat /sys/class/mtd/$(basename /dev/mtd0)/erasesize)"
+  ebs="$(cat /sys/class/mtd/mtd0/erasesize)"
   off="$init_off"
   skip="$((init_off / ebs))"
 


### PR DESCRIPTION
This $(basename /dev/mtd0) seems gratuitous, considering /dev/mtd0 is a static string, why not just say mtd0, as it can't resolve to anything else?